### PR TITLE
Fix remote code execution #1

### DIFF
--- a/set.php
+++ b/set.php
@@ -1,6 +1,6 @@
 <?php
 
-	shell_exec('echo "25='.$_GET['v'].'" > /dev/pi-blaster');
+	shell_exec('echo "25='.escapeshellarg($_GET['v']).'" > /dev/pi-blaster');
 	echo "success";
 
 ?>


### PR DESCRIPTION
Remote code execution due to unsanitized user input being passed to shell_exec.
